### PR TITLE
Use keyword args to clarify intent

### DIFF
--- a/lib/errnie.rb
+++ b/lib/errnie.rb
@@ -4,18 +4,18 @@ require 'errnie/errors'
 require 'errnie/services/base'
 
 class Errnie
-  def self.notify(exception_or_error_message, options={}, &block)
-    service = options.delete(:service) || configuration.default_service
-    new(service).notify(exception_or_error_message, options={}, &block)
+  def self.notify(exception_or_error_message, service: nil, metadata: {}, service_options: {}, &block)
+    service = service || configuration.default_service
+    new(service).notify(exception_or_error_message, metadata: metadata, service_options: service_options, &block)
   end
 
-  def initialize(service=default_service)
+  def initialize(service)
     @service = service
     @adapter_klass = adapter_for_service
   end
 
-  def notify(exception_or_error_message, options={}, &block)
-    adapter = @adapter_klass.new(exception_or_error_message, options)
+  def notify(exception_or_error_message, metadata: {}, service_options: {}, &block)
+    adapter = @adapter_klass.new(exception_or_error_message, metadata: metadata, service_options: service_options)
     adapter.notify(&block)
   end
 

--- a/lib/errnie/services/appsignal.rb
+++ b/lib/errnie/services/appsignal.rb
@@ -7,15 +7,11 @@ class Errnie
   module Services
     class Appsignal < Base
       def notify(&block)
-        ::Appsignal.send_error(error, options, &block)
+        ::Appsignal.send_error(error, @metadata, &block)
       end
 
       def error
         @error ||= klassify_error
-      end
-
-      def options
-        @raw_options
       end
 
       private

--- a/lib/errnie/services/base.rb
+++ b/lib/errnie/services/base.rb
@@ -1,9 +1,10 @@
 class Errnie
   module Services
     class Base
-      def initialize(exception_or_error_message, raw_options={})
+      def initialize(exception_or_error_message, metadata: {}, service_options: {})
         @exception_or_error_message = exception_or_error_message
-        @raw_options = raw_options
+        @metadata = metadata
+        @service_options = service_options
       end
 
       def notify

--- a/lib/errnie/services/bugsnag.rb
+++ b/lib/errnie/services/bugsnag.rb
@@ -7,25 +7,25 @@ class Errnie
   module Services
     class Bugsnag < Base
       def notify(&block)
-        ::Bugsnag.notify(error, auto_notify, &block)
+        if block_given?
+          ::Bugsnag.notify(error, auto_notify, &block)
+        elsif @metadata && !@metadata.empty?
+          ::Bugsnag.notify(error, auto_notify) do |notification|
+            notification.add_tab(:metadata, @metadata)
+          end
+        else
+          ::Bugsnag.notify(error, auto_notify)
+        end
       end
 
       def error
         @exception_or_error_message
       end
 
-      def options
-        @raw_options
-      end
-
       private
 
       def auto_notify
-        bugsnag_options[:auto_notify]
-      end
-
-      def bugsnag_options
-        @bugsnag_options ||= @raw_options.fetch(:bugsnag_options, {})
+        @service_options[:auto_notify]
       end
     end
   end

--- a/spec/errnie/services/appsignal_spec.rb
+++ b/spec/errnie/services/appsignal_spec.rb
@@ -4,13 +4,13 @@ require 'errnie/services/appsignal'
 RSpec.describe Errnie::Services::Appsignal do
   describe '#notify' do
     let(:error)    { StandardError.new('testing 123') }
-    let(:options)  { {} }
-    let!(:service) { described_class.new(error, options) }
+    let(:metadata) { { key: :value } }
+    let!(:service) { described_class.new(error, metadata: metadata) }
 
     subject { service.notify }
 
     it 'notifies via Appsignal' do
-      expect(::Appsignal).to receive(:send_error).with(error, options)
+      expect(::Appsignal).to receive(:send_error).with(error, metadata)
       subject
     end
   end

--- a/spec/errnie/services/bugsnag_spec.rb
+++ b/spec/errnie/services/bugsnag_spec.rb
@@ -4,8 +4,8 @@ require 'errnie/services/bugsnag'
 RSpec.describe Errnie::Services::Bugsnag do
   describe '#notify' do
     let(:error)    { StandardError.new('testing 123') }
-    let(:options)  { {} }
-    let!(:service) { described_class.new(error, options) }
+    let(:metadata) { { key: :value } }
+    let!(:service) { described_class.new(error, metadata: metadata) }
 
     subject { service.notify }
 

--- a/spec/errnie_spec.rb
+++ b/spec/errnie_spec.rb
@@ -5,29 +5,27 @@ RSpec.describe Errnie do
   describe '.notify' do
     let(:error) { StandardError.new('testing 123') }
 
-    subject { described_class.notify(error, options) }
+    subject { described_class.notify(error, metadata: metadata) }
 
     context 'when no service is specified' do
       before { described_class.configure {|c| c.default_service = 'Bugsnag'} }
 
-      let(:options)  { {} }
+      let(:metadata) { { key: :value } }
 
       it 'uses the default' do
         expect(Errnie::Services::Bugsnag).to receive(:new)
-          .with(error, options).and_call_original
+          .with(error, metadata: metadata, service_options: {}).and_call_original
 
         subject
       end
     end
 
     context 'when service is specified' do
-      let(:options)  {
-        { service: 'Appsignal' }
-      }
+      subject { described_class.notify(error, service: 'Appsignal') }
 
       it 'uses the service' do
         expect(Errnie::Services::Appsignal).to receive(:new)
-          .with(error, options).and_call_original
+          .with(error, metadata: {}, service_options: {}).and_call_original
 
         subject
       end
@@ -36,18 +34,18 @@ RSpec.describe Errnie do
 
   describe '#notify' do
     let(:error)    { StandardError.new('testing 123') }
-    let(:options)  { {} }
+    let(:metadata) { { key: :value } }
     let!(:errnie)  { described_class.new(service) }
 
-    subject { errnie.notify(error, options) }
+    subject { errnie.notify(error, metadata: metadata) }
 
     [:Appsignal, :Bugsnag].each do |service_name|
       context "using #{service_name}" do
         let(:service) { service_name }
         let(:klass)   { Errnie::Services.const_get(service_name.to_s) }
 
-        it "instantiates the service with the error and options" do
-          expect(klass).to receive(:new).with(error, options).and_call_original
+        it "instantiates the service with the error, metadata, and service options" do
+          expect(klass).to receive(:new).with(error, metadata: metadata, service_options: {}).and_call_original
           subject
         end
 


### PR DESCRIPTION
* `metadata` gets passed along with the error
* `service_options` get passed to the underlying adapter
* `service` can be provided at the class-level to switch adapters on the fly