### PR TITLE
Support AppSignal Ruby v3

### DIFF
--- a/.dockerdev/.bashrc
+++ b/.dockerdev/.bashrc
@@ -1,0 +1,1 @@
+alias be="bundle exec"

--- a/.dockerdev/Aptfile
+++ b/.dockerdev/Aptfile
@@ -1,0 +1,2 @@
+vim
+pkg-config

--- a/.dockerdev/Dockerfile
+++ b/.dockerdev/Dockerfile
@@ -1,0 +1,49 @@
+ARG RUBY_VERSION
+FROM ruby:$RUBY_VERSION-slim-buster
+
+ARG BUNDLER_VERSION
+
+# Common dependencies
+RUN apt-get update -qq \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+    build-essential \
+    gnupg2 \
+    curl \
+    less \
+    git \
+  && apt-get clean \
+  && rm -rf /var/cache/apt/archives/* \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && truncate -s 0 /var/log/*log
+
+# Install dependencies
+COPY Aptfile /tmp/Aptfile
+RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrade && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+    $(grep -Ev '^\s*#' /tmp/Aptfile | xargs) && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    truncate -s 0 /var/log/*log
+
+# Configure bundler
+ENV LANG=C.UTF-8 \
+  BUNDLE_JOBS=4 \
+  BUNDLE_RETRY=3
+
+# Uncomment this line if you store Bundler settings in the project's root
+# ENV BUNDLE_APP_CONFIG=.bundle
+
+# Uncomment this line if you want to run binstubs without prefixing with `bin/` or `bundle exec`
+# ENV PATH /app/bin:$PATH
+
+# Upgrade RubyGems and install required Bundler version
+# See https://github.com/evilmartians/terraforming-rails/pull/24 for discussion
+RUN gem update --system && \
+    rm /usr/local/lib/ruby/gems/*/specifications/default/bundler-*.gemspec && \
+    gem uninstall bundler && \
+    gem install bundler -v $BUNDLER_VERSION
+
+# Create a directory for the app code
+RUN mkdir -p /app
+
+WORKDIR /app

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,51 @@
+.git
+.gitignore
+
+#
+# OS X
+#
+.DS_Store
+.AppleDouble
+.LSOverride
+# Icon must end with two \r
+Icon
+# Thumbnails
+._*
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+#
+# Rails
+#
+*.rbc
+capybara-*.html
+log
+db/*.sqlite3
+db/*.sqlite3-journal
+public/system
+yarn-error.log
+yarn-debug.log*
+.yarn-integrity
+external_dns.log
+
+coverage/
+spec/tmp
+**.orig
+
+.bundle
+
+.ruby-gemset
+
+.rvmrc
+
+# if using bower-rails ignore default bower_components path bower.json files
+# vendor/assets/bower_components
+# *.bowerrc
+# bower.json

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,21 +13,21 @@ on:
   pull_request:
     branches: [ master ]
 
+
 jobs:
   test:
-
-    runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
+        ruby: [2.5, 2.6, 2.7, '3.0']
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+    - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
-    - name: Install dependencies
-      run: bundle install
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: bundle exec rake

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 .rspec_status
 
 .rbenv*
+
+Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ Blocks get passed along to the underlying service's gem. Refer to the service ge
 
 ## Development
 
+### via Docker
+
+* Check out the repo
+* In the terminal
+  * Run `docker-compose build runner`
+  * When the container is built, run `docker-compose run --rm runner` to launch an app environment for dev
+  * Run `bin/setup`
+
+### via local machine
+
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '2.4'
+
+x-app: &app
+  build:
+    context: .dockerdev
+    dockerfile: Dockerfile
+    args:
+      RUBY_VERSION: '2.5.5'
+      BUNDLER_VERSION: '2.2.11'
+  environment: &env
+    RUBY_ENV: ${RUBY_ENV:-development}
+  image: errnie-dev:0.1.0
+  tmpfs:
+    - /tmp
+
+x-backend: &backend
+  <<: *app
+  stdin_open: true
+  tty: true
+  volumes:
+    - .:/app:cached
+    - bundle:/usr/local/bundle
+  environment:
+    <<: *env
+    HISTFILE: /app/log/.bash_history
+    EDITOR: vi
+
+services:
+  runner:
+    <<: *backend
+    command: /bin/bash
+
+volumes:
+  bundle:

--- a/errnie.gemspec
+++ b/errnie.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "appsignal", "~> 2.9"
+  spec.add_development_dependency "appsignal", "~> 3.0"
   spec.add_development_dependency "bugsnag", "~> 6.0"
 end

--- a/lib/errnie/services/appsignal.rb
+++ b/lib/errnie/services/appsignal.rb
@@ -1,6 +1,6 @@
 require 'errnie/services/base'
 
-gem 'appsignal', '~> 2.10'
+gem 'appsignal', '~> 3.0'
 require 'appsignal'
 
 class Errnie


### PR DESCRIPTION
Updating the gem dependencies to support [AppSignal's v3 release](https://github.com/appsignal/appsignal-ruby/blob/HEAD/CHANGELOG.md#300). Also adds Docker configs for development.