### PR TITLE
Report metadata as sample data in Appsignal

### DIFF
--- a/lib/errnie/services/appsignal.rb
+++ b/lib/errnie/services/appsignal.rb
@@ -7,7 +7,15 @@ class Errnie
   module Services
     class Appsignal < Base
       def notify(&block)
-        ::Appsignal.send_error(error, @metadata, &block)
+        if block_given?
+          ::Appsignal.send_error(error, &block)
+        elsif @metadata && !@metadata.empty?
+          ::Appsignal.send_error(error) do |notification|
+            notification.set_sample_data("custom_data", @metadata)
+          end
+        else
+          ::Appsignal.send_error(error)
+        end
       end
 
       def error

--- a/spec/errnie/services/appsignal_spec.rb
+++ b/spec/errnie/services/appsignal_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Errnie::Services::Appsignal do
     subject { service.notify }
 
     it 'notifies via Appsignal' do
-      expect(::Appsignal).to receive(:send_error).with(error, metadata)
+      expect(::Appsignal).to receive(:send_error).with(error)
       subject
     end
   end
@@ -37,4 +37,3 @@ RSpec.describe Errnie::Services::Appsignal do
     end
   end
 end
-


### PR DESCRIPTION
Passing this info as an argument is deprecated in Appsignal 3+
https://github.com/appsignal/appsignal-ruby/pull/702